### PR TITLE
Update some code for Julia 5.0 and Fix a typo

### DIFF
--- a/src/moj-03-variables-data-types.jl
+++ b/src/moj-03-variables-data-types.jl
@@ -105,8 +105,8 @@ Float64(3)
 #
 # convert() will check for loss of precision.
 #
-convert(Int64, 3.5)	# Will generate InexactError.
-Int64(3.5)					# Will generate InexactError too.
+convert(Int64, 3.5)	                                # Will generate InexactError.
+Int64(3.5)					        # Will generate InexactError too.
 
 # Converting values to a common type.
 #

--- a/src/moj-03-variables-data-types.jl
+++ b/src/moj-03-variables-data-types.jl
@@ -103,10 +103,10 @@ issubtype(Float64, AbstractFloat)
 convert(Float64, 3)
 Float64(3)
 #
-# Whereas convert() will check for loss of precision, converting with a type name will not.
+# convert() will check for loss of precision.
 #
-convert(Int64, 3.5)
-Int64(3.5)
+convert(Int64, 3.5)	# Will generate InexactError.
+Int64(3.5)					# Will generate InexactError too.
 
 # Converting values to a common type.
 #
@@ -225,7 +225,7 @@ typeof(s2)
 
 # Integer code for a character.
 #
-int('a')
+Int('a')
 #
 # Integer arithmetic works on characters.
 #
@@ -342,9 +342,7 @@ end
 
 # More information at https://en.wikibooks.org/wiki/Introducing_Julia/Working_with_dates_and_times.
 
-using Dates
-
-vandag = today()			# Today's date			-> Date class
+vandag = Dates.today()			# Today's date			-> Date class
 nou = now()				# Now! (date and time)		-> DateTime class
 
 time()					# UNIX time, which can be formatted with strftime()
@@ -354,7 +352,7 @@ time()					# UNIX time, which can be formatted with strftime()
 Dates.Date("2015-08-17", "yyyy-mm-dd")
 Dates.DateTime("2015-08=17 12,23]59", "yyyy-mm=dd HH,MM]SS")
 #
-# And formatting to a string. 
+# And formatting to a string.
 #
 Dates.format(nou, "yy/mm/dd HH:MM:SS.ss")
 #
@@ -363,19 +361,19 @@ Dates.format(nou, "yy/mm/dd HH:MM:SS.ss")
 fmt = Dates.DateFormat("yy/mm/dd HH:MM:SS.ss");
 Dates.format(nou, fmt)
 
-year(vandag)
-month(vandag)
-day(vandag)
+Dates.year(vandag)
+Dates.month(vandag)
+Dates.day(vandag)
 #
 # There is a range of other functions including dayofweek(), dayname(), monthname(), yearmonth(), yearmonthday() and
 # isleapyear().
 #
-hour(nou)
-minute(nou)
-second(nou)
+Dates.hour(nou)
+Dates.minute(nou)
+Dates.second(nou)
 
-firstdayofweek(vandag)
-firstdayofmonth(vandag)
+Dates.firstdayofweek(vandag)
+Dates.firstdayofmonth(vandag)
 
 # What is date next Monday?
 #
@@ -386,11 +384,11 @@ Dates.tonext(d -> Dates.dayofweek(d) == Dates.Monday, vandag)
 # Arithmetic.
 #
 now() - nou
-vanday + Dates.Year(1) + Dates.Month(3) + Dates.Day(2)
+vandag + Dates.Year(1) + Dates.Month(3) + Dates.Day(2)
 
 # Ranges.
 #
-collect(Date(2015,1,1):Day(7):Date(2016,1,1))	# One week intervals
+collect(Date(2015,1,1):Dates.Day(7):Date(2016,1,1))	# One week intervals
 
 # Timing execution.
 #

--- a/src/moj-04-functions.jl
+++ b/src/moj-04-functions.jl
@@ -44,6 +44,8 @@ rectangle(2, 3; θ = pi / 3, color = "red")
 # Examples from J. Bezanson, A. Edelman, S. Karpinski, and V. B. Shah, “Julia: A Fresh Approach to Numerical Computing,”
 # arXiv, vol. 1411.1607v, 2014.
 #
+import Base.*
+
 *(a::Number, g::Function)= x->a*g(x)            # Scale output
 *(f::Function, t::Number) = x->f(t*x)           # Scale argument
 *(f::Function, g::Function)= x->f(g(x))         # Function composition
@@ -80,8 +82,8 @@ x = [3, 4]
 # Interesting application of the splat.
 #
 [rand(2,2) for n in 1:5]                        # A 5-element 1D array of 2x2 arrays.
-[[rand(2,2) for n in 1:5]...]                   # A 10x2 array.
-[[[rand(2,2) for n in 1:5]...]...]              # A 20-element 1D array.
+[[rand(2,2) for n in 1:5]...]                   # No difference.
+[[[rand(2,2) for n in 1:5]...]...]              # No difference.
 
 # MULTIPLE DISPATCH ---------------------------------------------------------------------------------------------------
 
@@ -98,7 +100,7 @@ x = [3, 4]
 # This feature is known as "multiple dispatch".
 
 # n.method(x, y)                - Object Oriented languages
-# method(n, x, y)               - Julia 
+# method(n, x, y)               - Julia
 #
 # Traditional Object Oriented programming languages implement single dispatch where method calls are attached to a
 # particular object (n in the examples above), which is then in some sense "special". Julia's multiple dispatch selects
@@ -129,10 +131,10 @@ divide(6, 4)
 divide(3.5, 2.0)
 
 # Now we can define a new method for the same function (effectively "overloading" the function) specialised for
-# FloatingPoint types. Effectively this new function acts like a filter: if there is no function defined for a
+# AbstractFloat types. Effectively this new function acts like a filter: if there is no function defined for a
 # particular combination of types then the generic function is used.
 #
-function divide(x::FloatingPoint, y::FloatingPoint)
+function divide(x::AbstractFloat, y::AbstractFloat)
     x / y
 end
 #
@@ -177,7 +179,7 @@ sum(["Hello", "World!"])                            # Functions that depend on "
 #
 4 * "xxx"                                           # Doesn't work.
 #
-function *(n::Unsigned, txt::String)
+function *(n::Signed, txt::String)
     txt^n
 end
 4 * "xxx"

--- a/src/moj-05-collections.jl
+++ b/src/moj-05-collections.jl
@@ -20,7 +20,7 @@ y = [3, "foo", 'a']                 # Elements can be of mixed type
 typeof(y)                           # Type of the Array itself
 eltype(y)                           # Type of the elements in the Array
 #
-Array{ASCIIString, 1}(["dog", "cat", "mouse"])
+Array{String, 1}(["dog", "cat", "mouse"])
 Array{Float32, 1}([1, 2, 3])        # Convert the integers to float32
 #
 Array(Int32, 2, 3)                  # Uninitialised Array with specified shape
@@ -63,7 +63,7 @@ typeof(0:10)
 collect(range(0, 0.5, 11))          # Range interpreted into an array
 collect(0:0.5:5)
 collect(0:10)
-typeof(collect(0:10)
+typeof(collect(0:10))
 
 # Searching.
 #
@@ -77,6 +77,7 @@ find([0, 1, 0, 5, 0, 1, 0, true])   # Find indices of all non-zero elements
 find(isodd, x)                      # Find indices of all odd elements.
 #
 findnext(x, 1, 3)
+using Primes                        # Run Pkg.add("Primes") to install this Primes
 findnext(isprime, x, 4)             # Find next prime element, starting at index 4.
 
 # Counting.
@@ -227,8 +228,8 @@ typeof((1, 2, 3.5, "Hello"))
 
 # Type annotation and assertion.
 #
-(1, "zap!")::(Int64, String)
-(1, "zap!")::(Int64, Real)      # TypeError
+(1, "zap!")::Tuple{Int64, String}
+(1, "zap!")::Tuple{Int64, Real}      # TypeError
 
 # Tuple types enumerate the types of each element in the tuple.
 #

--- a/src/moj-05-collections.jl
+++ b/src/moj-05-collections.jl
@@ -244,7 +244,7 @@ fibtuple[4:end]
 
 # Tuples are immutable.
 #
-fibtuple[4] = 9                 # This will generate an error!
+fibtuple[4] = 9                      # This will generate an error!
 
 # Tuples support iteration.
 #

--- a/src/moj-06-composite-types.jl
+++ b/src/moj-06-composite-types.jl
@@ -123,8 +123,8 @@ abstract Document
 type JournalArticle <: Document
     author::Array{AbstractString, 1}
     title::AbstractString
-    DOI::ASCIIString
-    journal::AbstractString
+    DOI::String
+    journal::String
     year::Unsigned
     volume::Unsigned
     number::Unsigned
@@ -200,7 +200,6 @@ book                        # ... replaced by a "pretty" look.
 
 # String representation. This is analogous to __str__ in Python.
 #
-import Base.string
 string(doc::Document) = citation(doc)
 
 # The Book and JournalArticle types have many commonalities and we might want to define functions that work on

--- a/src/moj-07-functional.jl
+++ b/src/moj-07-functional.jl
@@ -40,9 +40,10 @@ end
 
 # filter(F, collection) returns only those elements of collection for which function F returns true.
 #
-filter(n -> n % 3 == 0, [0:10])
+filter(n -> n % 3 == 0, 0:10)
 
-filter(isprime, [1:100])                # Find values (not indices!) which are prime.
+import Primes: isprime
+filter(isprime, 1:100)                # Find values (not indices!) which are prime.
 #
 # filter!() will modify its argument in place, applying the filter.
 
@@ -64,7 +65,7 @@ reduce(max, [1, 2, 3])
 
 # Map and Reduce.
 #
-mapreduce(x -> x^2, +, [1:5])               # See also mapfoldl() and mapfoldr().
+mapreduce(x -> x^2, +, 1:5)               # See also mapfoldl() and mapfoldr().
 (((1^2 + 2^2) + 3^2) + 4^2) + 5^2
 
 # ZIP -----------------------------------------------------------------------------------------------------------------
@@ -84,4 +85,3 @@ map(x -> sum(x), zip(1:4, 5:8))
 # This will create a 3x3 array. By default the type of the array would be Float, but we can force it to be an integer.
 #
 Int64[x / y for x in [16, 8, 4], y in [4, 2, 1]]
-

--- a/src/moj-08-control.jl
+++ b/src/moj-08-control.jl
@@ -65,6 +65,7 @@ fib(5)
 #
 # And a factorial operator (well, close enough to the correct notation!)
 #
+import Base:!
 !(n) = n < 2 ? 1 : n * !(n-1)
 !10
 # Compare with builtin
@@ -137,8 +138,8 @@ factorial(-1)
 #
 # All exceptions are derived from the Exception type.
 #
-super(DomainError)
-super(ArgumentError)
+supertype(DomainError)
+supertype(ArgumentError)
 
 # Raise exceptions with throw().
 #


### PR DESCRIPTION
# moj-03:
1. It seems `Int64(3.5)` will raise InexactError too.
2. `int()` is undefined.
3. `Dates` package has been merged into the Base Standard Library.
4. Fix a typo at line 389: `vanday` -> `vandag`.

# moj-04:
1. function Base.* must be explicitly imported to be extended
2. Update for Julia 5.0.
3. `FloatingPoint` has been renamed to `AbstractFloat`: https://github.com/JuliaLang/julia/pull/12162
4. Int64 is not a subclass of Unsigned.

# moj-05
1. ASCIIString is deprecated, use String instead.
2. `isprime` is moved to Package Primes
3. Syntax error

# moj-07
1. add import `isprime`
2. fix some syntax errors

# moj-08
1. `super` is deprecated, use `supertype` instead
2. fix syntax error: invalid operator.

Only tested in Julia 5.0.